### PR TITLE
fix:  for correct operation with huawei switches  on gnetcli_adapter.py

### DIFF
--- a/src/gnetcli_adapter/gnetcli_adapter.py
+++ b/src/gnetcli_adapter/gnetcli_adapter.py
@@ -34,6 +34,8 @@ breed_to_device = {
     "jun10": "juniper",
     "eos4": "arista",
     "h3c": "h3c",
+    "vrp85": "huawei",
+    "vrp55": "huawei",
 }
 
 DEFAULT_GNETCLI_SERVER_CONF = """
@@ -101,7 +103,7 @@ async def get_config(breed: str) -> List[str]:
         return ["show configuration"]
     elif breed.startswith("eos4"):
         return ["show running-config | no-more"]
-    elif breed.startswith(("h3c", "huawei")):
+    elif breed.startswith(("h3c", "vrp")):
         return ["display current-configuration"]
     raise Exception("unknown breed %r" % breed)
 


### PR DESCRIPTION
Fix for correct operation with huawei switches


[11:01:32]   ERROR MainProcess - /Users/Desktop/.venv/src/annet/annet/gen.py:731 - config error GnetcliException('AioRpcError unknown device vrp55 req_id:ba13469a-14a8-4f4c-baa0-4ecd1b21ffb3') -- host='huawei'