### PR TITLE
fix: Redirect gnetcli_server stdout to devnull

### DIFF
--- a/src/gnetcli_adapter/gnetcli_adapter.py
+++ b/src/gnetcli_adapter/gnetcli_adapter.py
@@ -155,7 +155,7 @@ def run_gnetcli_server(server_path: str, config: str = DEFAULT_GNETCLI_SERVER_CO
     try:
         proc = subprocess.Popen(
             [gnetcli_abs_path, "--conf-file", "-"],
-            stdout=subprocess.PIPE,
+            stdout=subprocess.DEVNULL, # we do not read stdout
             stderr=subprocess.PIPE,
             stdin=subprocess.PIPE,
             bufsize=1,


### PR DESCRIPTION
This is a potential bug if gnetcli_server for some reason try to write to stdout it will hang.
Its safer to redirect stdout into devnull if we do not drain data from it on adapter's side.
