### PR TITLE
feat: support running gnetcli_server with unix socket

### DIFF
--- a/src/gnetcli_adapter/gnetcli_adapter.py
+++ b/src/gnetcli_adapter/gnetcli_adapter.py
@@ -188,6 +188,8 @@ def run_gnetcli_server(server_path: str, config: str = DEFAULT_GNETCLI_SERVER_CO
                 else:
                     if data.get("msg") == "init tcp socket":
                         _local_gnetcli_url = data.get("address")
+                    if data.get("msg") == "init unix socket":
+                        _local_gnetcli_url = "unix:" + data.get("path")
                     if data.get("level") == "panic":
                         _logger.error("gnetcli error %s", data)
     _logger.debug("set gnetcli server exit code %s", proc.returncode)


### PR DESCRIPTION
Parse a unix socket path from gnetclit_server log.

Example of gnetcli_server configuration:
```
 {
     ...
     "disable_tcp": True,
     "unix_socket": /tmp/sock.xxxx,
 }
```

In case both "port" and "unix_socket" are provided in config gnetclit_server_adapter will choose any one of then. Currently gnetclit_server reports unix socket first and tcp socket second, so tcp socket will be preffered.