### PR TITLE
fix: pass read_timeout to gnetcli commands

### DIFF
--- a/src/gnetcli_adapter/gnetcli_adapter.py
+++ b/src/gnetcli_adapter/gnetcli_adapter.py
@@ -513,6 +513,7 @@ class GnetcliDeployer(DeployDriver, AdapterWithConfig, AdapterWithName):
                         res = await session.cmd(
                             cmd=cmd.cmd,
                             cmd_timeout=cmd.timeout,
+                            read_timeout=cmd.read_timeout,
                             host_params=host_params,
                             qa=parse_annet_qa(cmd.questions or []),
                             trace=True,


### PR DESCRIPTION
Add missing read_timeout parameter