### PR TITLE
feat: export without verbose for routeros and add breed routeros7

### DIFF
--- a/src/gnetcli_adapter/gnetcli_adapter.py
+++ b/src/gnetcli_adapter/gnetcli_adapter.py
@@ -41,6 +41,7 @@ except ImportError:
 
 breed_to_device = {
     "routeros": "ros",
+    "routeros7": "ros7",
     "ios12": "cisco",
     "bcom-os": "bcomos",
     "pc": "pc",
@@ -99,8 +100,10 @@ class AppSettings(BaseSettings):
 
 
 async def get_config(breed: str) -> List[str]:
-    if breed == "routeros":
-        return ["/export verbose", "/user export verbose", "/file print terse detail", "/user ssh-keys print terse"]
+    if breed == "routeros7":
+        return ["/export show-sensitive", "/user export verbose show-sensitive", "/file print terse detail", "/user ssh-keys print terse"]
+    elif breed == "routeros":
+        return ["/export", "/user export verbose", "/file print terse detail", "/user ssh-keys print terse"]
     elif breed.startswith("ios") or breed.startswith("bcom") or breed.startswith("eltex") or breed.startswith("nxos"):
         return ["show running-config"]
     elif breed.startswith("jun"):


### PR DESCRIPTION
# Add RouterOS7 support and update RouterOS export

## Summary
- Added support for RouterOS7 breed with device mapping to `ros7`
- Changed RouterOS export command from `/export verbose` to `/export` (without verbose flag)
- Implemented specific export commands for RouterOS7 with `show-sensitive` flag

## Changes
- Added `routeros7` to `breed_to_device` dictionary
- Updated `get_config()` function to handle RouterOS7 separately
- Simplified RouterOS export by removing verbose flag

## Technical Details
**File:** `src/gnetcli_adapter/gnetcli_adapter.py`

**RouterOS7 export commands:**
- `/export show-sensitive`
- `/user export verbose show-sensitive`
- `/file print terse detail`
- `/user ssh-keys print terse`

**RouterOS export commands:**
- `/export` (changed from `/export verbose`)
- `/user export verbose`
- `/file print terse detail`
- `/user ssh-keys print terse`

## Rationale
- RouterOS7 requires separate handling due to syntax differences from RouterOS 6.x
- Removing verbose flag for RouterOS simplifies output and improves performance
- Using `show-sensitive` for RouterOS7 ensures complete configuration retrieval
