### PR TITLE
fix: aruba add no-encrypt to show running-config

### DIFF
--- a/src/gnetcli_adapter/gnetcli_adapter.py
+++ b/src/gnetcli_adapter/gnetcli_adapter.py
@@ -113,7 +113,7 @@ async def get_config(breed: str) -> List[str]:
     elif breed.startswith(("h3c", "vrp")):
         return ["display current-configuration"]
     elif breed.startswith("aruos"):
-        return ["show ap-env", "show running-config"]
+        return ["show ap-env", "show running-config no-encrypt"]
     raise Exception("unknown breed %r" % breed)
 
 


### PR DESCRIPTION
By default aruba replaces passwords in show run output with a RANDOM string.
 * Its not a real hash (ie can not be reused in the configuration).
 * And its not consistent between show runs (ie every time output changes).

Adding "no-encrypt" helps with a major caveat:
 * Unpriveleged is not permitted to run this command
 * Instead of a meaningful error aruba just returns an empty output

This means that `get_config()` will not work for users without admin privs.