### PR TITLE
fix: restore connecting to external gnetcli_server via `url`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,29 @@ Host mybastion
 
 `~/.annet/context.yml` the same because gnetcli read .ssh/config by default.
 
+## Connecting to an externally-running gnetcli_server
+
+If `gnetcli_server` is already running on a bastion host, set `url` and the
+adapter will connect to it instead of spawning a local server binary. `login`
+and `password` authenticate to the gnetcli server itself (Basic auth);
+`dev_login`/`dev_password` are still the network device credentials.
+
+```yaml
+fetcher:
+  default:
+    adapter: gnetcli
+    params: &gnetcli
+      url: 192.0.2.10:50051
+      login: gnetcli-user
+      password: gnetcli-secret
+      dev_login: mylogin
+      dev_password: mypassword
+deployer:
+  default:
+    adapter: gnetcli
+    params:
+      <<: *gnetcli
+```
+
+When `url` is unset, the adapter starts a local `gnetcli_server` subprocess
+(`server_path` defaults to `gnetcli_server` on `$PATH`).

--- a/src/gnetcli_adapter/gnetcli_adapter.py
+++ b/src/gnetcli_adapter/gnetcli_adapter.py
@@ -153,13 +153,20 @@ class ApiMaker(metaclass=abc.ABCMeta):
 
     @asynccontextmanager
     async def make_api(self) -> AsyncIterator[Gnetcli]:
-        async with GnetcliStarter(self.conf.server_path, self.conf.server_conf) as gnetcli_url:
-            yield Gnetcli(
-                server=gnetcli_url,
+        def _client(server_url: str) -> Gnetcli:
+            return Gnetcli(
+                server=server_url,
                 auth_token=self.conf.make_server_credentials(),
                 insecure_grpc=self.conf.insecure_grpc,
                 user_agent="annet",
             )
+
+        if self.conf.url:
+            yield _client(self.conf.url)
+            return
+
+        async with GnetcliStarter(self.conf.server_path, self.conf.server_conf) as gnetcli_url:
+            yield _client(gnetcli_url)
 
 
 class GnetcliFetcher(Fetcher, AdapterWithConfig, AdapterWithName, ApiMaker):

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -1,1 +1,18 @@
 from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+from gnetcli_adapter.gnetcli_adapter import GnetcliFetcher
+
+
+def test_make_api_uses_url_without_starter():
+    fetcher = GnetcliFetcher(url="127.0.0.1:50050")
+
+    async def run():
+        with patch("gnetcli_adapter.gnetcli_adapter.GnetcliStarter") as starter:
+            async with fetcher.make_api() as api:
+                assert api._server == "127.0.0.1:50050"
+            starter.assert_not_called()
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary

  Commit 87eacdf ("Gnetcli starter") rewrote `make_api` to always fork a local
  `gnetcli_server` via `GnetcliStarter`. The `url` field in `AppSettings` is
  still read but never used, so configs that point at an externally-running
  server crash with `FileNotFoundError: 'gnetcli_server'`.

  Restores the pre-87eacdf branch in `ApiMaker.make_api`: when `conf.url` is
  set, connect directly; otherwise spawn a local server as today.

  ## Changes

  - `gnetcli_adapter.py`: branch on `conf.url` in `make_api`.
  - `tests/test_methods.py`: assert `GnetcliStarter` is not invoked when `url` is set.
  - `README.md`: example for the external-server case.