### PR TITLE
fix: --entire-reload=force flag handling

### DIFF
--- a/src/gnetcli_adapter/gnetcli_adapter.py
+++ b/src/gnetcli_adapter/gnetcli_adapter.py
@@ -473,9 +473,8 @@ class GnetcliDeployer(DeployDriver, AdapterWithConfig, AdapterWithName, ApiMaker
         command_groups: list[tuple[str, CommandList]]= []
         if isinstance(cmds, dict): # PC
             files = self._get_files(cmds)
-            if args.entire_reload.value == "yes":
-                for file, cmdlist in self._get_reload_cmds(cmds).items():
-                    command_groups.append((f"Reload {file}", cmdlist))
+            for file, cmdlist in self._get_reload_cmds(cmds).items():
+                command_groups.append((f"Reload {file}", cmdlist))
         else:
             files = {}
             # treat each command as a group


### PR DESCRIPTION
The flag entire_reload controls if the reload commands should be executed
 * `yes`: default behaviour
 * `no`: upload files but do not reload services
 * `force`: reload even if there is no diff and no files was uploaded

This logic is handled in PCDeployer itself and here it should not be checked at all: https://github.com/annetutil/annet/blob/bf752eae4a45951786b295c6e8f3a035ca656044/annet/api/__init__.py#L567